### PR TITLE
Fix conditional check before adding cluster layer to map, add Suspense fallback in embed page, and update API URL in env example and hook

### DIFF
--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -1,8 +1,9 @@
 # API Configuration
-# Replace with your deployed API URL
-NEXT_PUBLIC_API_URL=https://your-dronewatch-api.vercel.app/api
+# IMPORTANT: For Vercel deployments, set this in Vercel Dashboard > Settings > Environment Variables
+# This must be set at BUILD TIME for Next.js to include it
+NEXT_PUBLIC_API_URL=https://dronewatchv2.vercel.app/api
 
-# Or use local development
+# For local development:
 # NEXT_PUBLIC_API_URL=http://localhost:8000/api
 
 # Optional: Mapbox for better map tiles

--- a/frontend/app/embed/page.tsx
+++ b/frontend/app/embed/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { Suspense } from 'react'
 import { useSearchParams } from 'next/navigation'
 import dynamic from 'next/dynamic'
 import { useIncidents } from '@/hooks/useIncidents'
@@ -9,7 +10,7 @@ const Map = dynamic(() => import('@/components/Map'), {
   loading: () => <div className="w-full h-full bg-gray-100 animate-pulse" />
 })
 
-export default function EmbedPage() {
+function EmbedContent() {
   const searchParams = useSearchParams()
 
   // Parse embed parameters
@@ -51,5 +52,17 @@ export default function EmbedPage() {
         </div>
       </div>
     </div>
+  )
+}
+
+export default function EmbedPage() {
+  return (
+    <Suspense fallback={
+      <div className="w-full h-screen bg-gray-100 animate-pulse flex items-center justify-center">
+        <div className="text-gray-500">Loading...</div>
+      </div>
+    }>
+      <EmbedContent />
+    </Suspense>
   )
 }

--- a/frontend/components/Map.tsx
+++ b/frontend/components/Map.tsx
@@ -49,7 +49,9 @@ export default function Map({ incidents, isLoading, center, zoom }: MapProps) {
       maxClusterRadius: 50,
     })
 
-    mapInstanceRef.current.addLayer(clusterRef.current)
+    if (clusterRef.current) {
+      mapInstanceRef.current.addLayer(clusterRef.current)
+    }
 
     return () => {
       if (mapInstanceRef.current) {

--- a/frontend/hooks/useIncidents.ts
+++ b/frontend/hooks/useIncidents.ts
@@ -1,7 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import type { Incident, FilterState } from '@/types'
 
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000/api'
+// Use the deployed API URL
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://dronewatchv2.vercel.app/api'
 
 async function fetchIncidents(filters: FilterState): Promise<Incident[]> {
   const params = new URLSearchParams({


### PR DESCRIPTION
## Summary
- Adds a conditional check to ensure `clusterRef.current` exists before adding it as a layer to the map
- Wraps the embed page content in a React `Suspense` component with a loading fallback
- Updates the example environment variable for the API URL to the deployed URL
- Updates the `useIncidents` hook to use the deployed API URL as a fallback

## Changes

### Frontend Components
- **Map.tsx**: Updated the map layer addition logic to include a safety check for `clusterRef.current` to prevent potential runtime errors
- **embed/page.tsx**: Refactored to wrap the embed content in a `Suspense` component with a loading placeholder to improve loading state handling

### Configuration
- **.env.local.example**: Updated `NEXT_PUBLIC_API_URL` to the deployed API URL with comments for Vercel and local development

### Hooks
- **useIncidents.ts**: Changed the fallback API URL to the deployed API URL

## Test plan
- [ ] Verify that the map loads correctly with clusters when `clusterRef.current` is defined
- [ ] Confirm no errors occur if `clusterRef.current` is undefined or null
- [ ] Test map interactions to ensure clustering behaves as expected
- [ ] Verify the embed page shows the loading fallback while the map component is loading
- [ ] Confirm the embed content renders correctly after loading
- [ ] Confirm the API URL is correctly used from environment variables or falls back to the deployed URL

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4fb15d4b-25cf-4203-a6f5-e097f413c30a
