### PR TITLE
Update API URL fallback in useIncidents hook

### DIFF
--- a/frontend/hooks/useIncidents.ts
+++ b/frontend/hooks/useIncidents.ts
@@ -1,8 +1,8 @@
 import { useQuery } from '@tanstack/react-query'
 import type { Incident, FilterState } from '@/types'
 
-// Use the deployed API URL
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://dronewatchv2.vercel.app/api'
+// Use the deployed API URL (preview URL until main is fixed)
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://dronewatchv2-q4a13cy9t-arnarssons-projects.vercel.app/api'
 
 async function fetchIncidents(filters: FilterState): Promise<Incident[]> {
   const params = new URLSearchParams({


### PR DESCRIPTION
## Summary
- Updated the fallback API URL in the `useIncidents` hook to use a preview deployment URL until the main URL is fixed.

## Changes

### Frontend
- **useIncidents.ts**: Changed the fallback `API_URL` from `https://dronewatchv2.vercel.app/api` to `https://dronewatchv2-q4a13cy9t-arnarssons-projects.vercel.app/api` to ensure the hook uses the correct preview API endpoint.

## Test plan
- [ ] Verify incidents are fetched correctly using the updated API URL.
- [ ] Confirm no errors occur when the environment variable `NEXT_PUBLIC_API_URL` is not set.
- [ ] Test the hook behavior in both development and production environments.

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4fb15d4b-25cf-4203-a6f5-e097f413c30a