### PR TITLE
Fix Python runtime specification in Vercel configuration

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -6,7 +6,7 @@
   "installCommand": "npm install",
   "functions": {
     "api/index.py": {
-      "runtime": "python3.11"
+      "runtime": "python@3.11"
     }
   },
   "rewrites": [

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/index.py": {
-      "runtime": "python3.11"
+      "runtime": "python@3.11"
     }
   },
   "rewrites": [


### PR DESCRIPTION
## Summary
- Corrects the Python runtime version format in Vercel configuration files

## Changes

### Configuration Updates
- Updated `frontend/vercel.json` and `vercel.json` to change the Python runtime from `python3.11` to `python@3.11` for the `api/index.py` function

## Test plan
- Verified that the runtime specification matches Vercel's expected format
- Ensured no disruption in deployment or function execution due to this change

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/4fb15d4b-25cf-4203-a6f5-e097f413c30a