### PR TITLE
Add asset_type filter to incidents API and improve Timeline controls

### DIFF
--- a/frontend/api/db.py
+++ b/frontend/api/db.py
@@ -53,7 +53,8 @@ async def fetch_incidents(
     limit: int = 200,
     offset: int = 0,
     status: Optional[str] = None,
-    country: Optional[str] = None
+    country: Optional[str] = None,
+    asset_type: Optional[str] = None
 ) -> List[Dict[str, Any]]:
     """
     Fetch incidents from database with retry logic for serverless environments.
@@ -88,6 +89,11 @@ async def fetch_incidents(
                 param_count += 1
                 query += f" AND i.country = ${param_count}"
                 params.append(country)
+
+            if asset_type:
+                param_count += 1
+                query += f" AND i.asset_type = ${param_count}"
+                params.append(asset_type)
 
             query += f" ORDER BY i.occurred_at DESC LIMIT ${param_count+1} OFFSET ${param_count+2}"
             params.extend([limit, offset])

--- a/frontend/api/incidents.py
+++ b/frontend/api/incidents.py
@@ -41,12 +41,15 @@ class handler(BaseHTTPRequestHandler):
         offset = int(query_params.get('offset', ['0'])[0])
         status = query_params.get('status', [None])[0]
         country = query_params.get('country', [None])[0]
+        asset_type = query_params.get('asset_type', [None])[0]
 
         # Handle 'all' values as no filter
         if status == 'all':
             status = None
         if country == 'all':
             country = None
+        if asset_type == 'all' or asset_type == '':
+            asset_type = None
 
         # Fetch incidents from database
         try:
@@ -55,7 +58,8 @@ class handler(BaseHTTPRequestHandler):
                 limit=limit,
                 offset=offset,
                 status=status,
-                country=country
+                country=country,
+                asset_type=asset_type
             ))
 
             # Check if it's an error response

--- a/frontend/components/Timeline.tsx
+++ b/frontend/components/Timeline.tsx
@@ -22,12 +22,8 @@ export function Timeline({ incidents, onTimeRangeChange, isOpen, onToggle }: Tim
   // Calculate date range from incidents
   const { minDate, maxDate, dateRange } = useIncidentDateRange(incidents)
 
-  // Initialize current date to earliest incident
-  useEffect(() => {
-    if (minDate && !currentDate) {
-      setCurrentDate(minDate)
-    }
-  }, [minDate, currentDate])
+  // Don't initialize current date automatically - let user activate timeline
+  // This prevents the timeline from filtering incidents on page load
 
   // Handle animation playback
   useEffect(() => {
@@ -77,8 +73,13 @@ export function Timeline({ incidents, onTimeRangeChange, isOpen, onToggle }: Tim
 
   const handleReset = useCallback(() => {
     setIsPlaying(false)
-    setCurrentDate(minDate)
-  }, [minDate])
+    setCurrentDate(null)
+  }, [])
+
+  const handleShowAll = useCallback(() => {
+    setIsPlaying(false)
+    setCurrentDate(null)
+  }, [])
 
   const handleDateChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setIsPlaying(false)
@@ -89,8 +90,12 @@ export function Timeline({ incidents, onTimeRangeChange, isOpen, onToggle }: Tim
   }, [dateRange])
 
   const togglePlay = useCallback(() => {
+    // Initialize current date on first play
+    if (!currentDate && minDate) {
+      setCurrentDate(minDate)
+    }
     setIsPlaying((prev) => !prev)
-  }, [])
+  }, [currentDate, minDate])
 
   const cycleSpeed = useCallback(() => {
     setPlaySpeed((prev) => {
@@ -178,12 +183,12 @@ export function Timeline({ incidents, onTimeRangeChange, isOpen, onToggle }: Tim
                 {isPlaying ? '⏸ Pause' : '▶ Play'}
               </button>
 
-              {/* Reset */}
+              {/* Show All / Reset */}
               <button
-                onClick={handleReset}
+                onClick={handleShowAll}
                 className="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors font-medium"
               >
-                ↺ Reset
+                {currentDate ? '✕ Show All' : '↺ Reset'}
               </button>
 
               {/* Speed */}


### PR DESCRIPTION
## Summary
- Added support for filtering incidents by `asset_type` in the API
- Enhanced Timeline component to improve user control over date filtering and playback

## Changes

### Backend API
- Updated `fetch_incidents` function to accept an optional `asset_type` parameter
- Modified SQL query to filter incidents by `asset_type` when provided
- Updated HTTP handler to parse `asset_type` query parameter and handle 'all' or empty values as no filter

### Frontend Timeline Component
- Removed automatic initialization of current date to earliest incident on load
- Added `handleShowAll` function to allow users to reset timeline view and show all incidents
- Modified play toggle to initialize current date on first play if not already set
- Updated reset button to toggle between "Show All" and "Reset" states based on current date

## Test plan
- [x] Verify incidents API filters correctly by `asset_type`
- [x] Confirm that timeline does not auto-filter incidents on page load
- [x] Test play/pause functionality initializes current date correctly
- [x] Validate "Show All" button resets timeline view as expected
- [x] Ensure no regressions in incident fetching and timeline playback behavior

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/64b1aefb-4b1e-48ad-9695-e948737a2146