### PR TITLE
Refactor frontend with new FilterPanel, EvidenceLegend, and view toggle

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useCallback, useMemo } from 'react'
 import dynamic from 'next/dynamic'
 import { Header } from '@/components/Header'
-import { Filters } from '@/components/Filters'
+import { FilterPanel } from '@/components/FilterPanel'
+import { EvidenceLegend } from '@/components/EvidenceLegend'
 import { IncidentList } from '@/components/IncidentList'
 import { Timeline } from '@/components/Timeline'
 import { Analytics } from '@/components/Analytics'
@@ -14,11 +15,12 @@ import type { FilterState, Incident } from '@/types'
 // Dynamic import for map (no SSR)
 const Map = dynamic(() => import('@/components/Map'), {
   ssr: false,
-  loading: () => <div className="w-full h-full bg-gray-100 animate-pulse" />
+  loading: () => <div className="w-full h-full bg-gray-100 dark:bg-gray-900 animate-pulse" />
 })
 
 export default function Home() {
   const [view, setView] = useState<'map' | 'list' | 'analytics'>('map')
+  const [isFilterPanelOpen, setIsFilterPanelOpen] = useState(false)
   const [isTimelineOpen, setIsTimelineOpen] = useState(false)
   const [timelineRange, setTimelineRange] = useState<{ start: Date | null; end: Date | null }>({
     start: null,
@@ -59,14 +61,43 @@ export default function Home() {
     <div className="flex flex-col h-screen bg-gray-50 dark:bg-gray-950 transition-colors">
       <Header incidentCount={incidents?.length || 0} isLoading={isLoading} />
 
-      <Filters
-        filters={filters}
-        onChange={handleFilterChange}
-        view={view}
-        onViewChange={setView}
-      />
+      {/* View Toggle Bar */}
+      <div className="bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800 px-4 py-2">
+        <div className="flex items-center justify-center gap-2">
+          <button
+            onClick={() => setView('map')}
+            className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
+              view === 'map'
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+            }`}
+          >
+            🗺️ Map
+          </button>
+          <button
+            onClick={() => setView('list')}
+            className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
+              view === 'list'
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+            }`}
+          >
+            📋 List
+          </button>
+          <button
+            onClick={() => setView('analytics')}
+            className={`px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
+              view === 'analytics'
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+            }`}
+          >
+            📊 Analytics
+          </button>
+        </div>
+      </div>
 
-      <main className="flex-1 relative overflow-hidden flex flex-col">
+      <main className="flex-1 relative overflow-hidden flex">
         {error && (
           <div className="absolute top-0 left-0 right-0 z-10 bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800 px-4 py-2">
             <p className="text-sm text-red-800 dark:text-red-200">
@@ -75,14 +106,18 @@ export default function Home() {
           </div>
         )}
 
+        {/* Main Content Area */}
         <div className="flex-1 relative overflow-auto">
           {view === 'map' ? (
-            <Map
-              incidents={incidents || []}
-              isLoading={isLoading}
-              center={[56.0, 10.5]}
-              zoom={6}
-            />
+            <>
+              <Map
+                incidents={incidents || []}
+                isLoading={isLoading}
+                center={[56.0, 10.5]}
+                zoom={6}
+              />
+              <EvidenceLegend />
+            </>
           ) : view === 'list' ? (
             <IncidentList
               incidents={incidents || []}
@@ -93,13 +128,24 @@ export default function Home() {
           )}
         </div>
 
-        {/* Timeline at bottom */}
-        <Timeline
-          incidents={allIncidents || []}
-          onTimeRangeChange={handleTimelineRangeChange}
-          isOpen={isTimelineOpen}
-          onToggle={() => setIsTimelineOpen(!isTimelineOpen)}
+        {/* Filter Panel (Desktop: Sidebar, Mobile: Drawer) */}
+        <FilterPanel
+          filters={filters}
+          onChange={handleFilterChange}
+          incidentCount={incidents?.length || 0}
+          isOpen={isFilterPanelOpen}
+          onToggle={() => setIsFilterPanelOpen(!isFilterPanelOpen)}
         />
+
+        {/* Timeline at bottom */}
+        {view === 'map' && (
+          <Timeline
+            incidents={allIncidents || []}
+            onTimeRangeChange={handleTimelineRangeChange}
+            isOpen={isTimelineOpen}
+            onToggle={() => setIsTimelineOpen(!isTimelineOpen)}
+          />
+        )}
       </main>
     </div>
   )

--- a/frontend/app/page_old.tsx
+++ b/frontend/app/page_old.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import { useState, useCallback, useMemo } from 'react'
+import dynamic from 'next/dynamic'
+import { Header } from '@/components/Header'
+import { Filters } from '@/components/Filters'
+import { IncidentList } from '@/components/IncidentList'
+import { Timeline } from '@/components/Timeline'
+import { Analytics } from '@/components/Analytics'
+import { useIncidents } from '@/hooks/useIncidents'
+import { isWithinInterval } from 'date-fns'
+import type { FilterState, Incident } from '@/types'
+
+// Dynamic import for map (no SSR)
+const Map = dynamic(() => import('@/components/Map'), {
+  ssr: false,
+  loading: () => <div className="w-full h-full bg-gray-100 animate-pulse" />
+})
+
+export default function Home() {
+  const [view, setView] = useState<'map' | 'list' | 'analytics'>('map')
+  const [isTimelineOpen, setIsTimelineOpen] = useState(false)
+  const [timelineRange, setTimelineRange] = useState<{ start: Date | null; end: Date | null }>({
+    start: null,
+    end: null,
+  })
+  const [filters, setFilters] = useState<FilterState>({
+    minEvidence: 1,
+    country: 'all',
+    status: 'all',
+    assetType: null,
+    dateRange: 'all'
+  })
+
+  const { data: allIncidents, isLoading, error } = useIncidents(filters)
+
+  // Apply timeline filtering on top of regular filters
+  const incidents = useMemo(() => {
+    if (!allIncidents) return []
+    if (!timelineRange.start || !timelineRange.end) return allIncidents
+
+    return allIncidents.filter((inc: Incident) =>
+      isWithinInterval(new Date(inc.occurred_at), {
+        start: timelineRange.start!,
+        end: timelineRange.end!,
+      })
+    )
+  }, [allIncidents, timelineRange])
+
+  const handleFilterChange = useCallback((newFilters: FilterState) => {
+    setFilters(newFilters)
+  }, [])
+
+  const handleTimelineRangeChange = useCallback((start: Date | null, end: Date | null) => {
+    setTimelineRange({ start, end })
+  }, [])
+
+  return (
+    <div className="flex flex-col h-screen bg-gray-50 dark:bg-gray-950 transition-colors">
+      <Header incidentCount={incidents?.length || 0} isLoading={isLoading} />
+
+      <Filters
+        filters={filters}
+        onChange={handleFilterChange}
+        view={view}
+        onViewChange={setView}
+      />
+
+      <main className="flex-1 relative overflow-hidden flex flex-col">
+        {error && (
+          <div className="absolute top-0 left-0 right-0 z-10 bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800 px-4 py-2">
+            <p className="text-sm text-red-800 dark:text-red-200">
+              Error loading incidents. Retrying...
+            </p>
+          </div>
+        )}
+
+        <div className="flex-1 relative overflow-auto">
+          {view === 'map' ? (
+            <Map
+              incidents={incidents || []}
+              isLoading={isLoading}
+              center={[56.0, 10.5]}
+              zoom={6}
+            />
+          ) : view === 'list' ? (
+            <IncidentList
+              incidents={incidents || []}
+              isLoading={isLoading}
+            />
+          ) : (
+            <Analytics incidents={incidents || []} />
+          )}
+        </div>
+
+        {/* Timeline at bottom */}
+        <Timeline
+          incidents={allIncidents || []}
+          onTimeRangeChange={handleTimelineRangeChange}
+          isOpen={isTimelineOpen}
+          onToggle={() => setIsTimelineOpen(!isTimelineOpen)}
+        />
+      </main>
+    </div>
+  )
+}

--- a/frontend/components/EvidenceLegend.tsx
+++ b/frontend/components/EvidenceLegend.tsx
@@ -1,0 +1,95 @@
+'use client'
+
+import { useState } from 'react'
+
+export function EvidenceLegend() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  return (
+    <div className="absolute bottom-20 left-4 z-[500]">
+      {/* Collapsed State */}
+      {!isOpen && (
+        <button
+          onClick={() => setIsOpen(true)}
+          className="bg-white dark:bg-gray-900 rounded-lg shadow-lg px-3 py-2 hover:shadow-xl transition-shadow border border-gray-200 dark:border-gray-800"
+        >
+          <div className="flex items-center gap-2">
+            <svg className="w-4 h-4 text-gray-600 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+            </svg>
+            <span className="text-xs font-medium text-gray-700 dark:text-gray-300">Legend</span>
+          </div>
+        </button>
+      )}
+
+      {/* Expanded State */}
+      {isOpen && (
+        <div className="bg-white dark:bg-gray-900 rounded-lg shadow-xl p-4 border border-gray-200 dark:border-gray-800 w-64">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-sm font-bold text-gray-900 dark:text-white">Evidence Levels</h3>
+            <button
+              onClick={() => setIsOpen(false)}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex items-start gap-2">
+              <div className="w-6 h-6 rounded-full bg-red-600 text-white flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">
+                4
+              </div>
+              <div>
+                <div className="text-sm font-medium text-gray-900 dark:text-white">Official Report</div>
+                <div className="text-xs text-gray-600 dark:text-gray-400">Police, military, or aviation authority</div>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-2">
+              <div className="w-6 h-6 rounded-full bg-orange-500 text-white flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">
+                3
+              </div>
+              <div>
+                <div className="text-sm font-medium text-gray-900 dark:text-white">Verified Media</div>
+                <div className="text-xs text-gray-600 dark:text-gray-400">Confirmed by trusted news sources</div>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-2">
+              <div className="w-6 h-6 rounded-full bg-yellow-400 text-white flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">
+                2
+              </div>
+              <div>
+                <div className="text-sm font-medium text-gray-900 dark:text-white">OSINT</div>
+                <div className="text-xs text-gray-600 dark:text-gray-400">Open-source intelligence</div>
+              </div>
+            </div>
+
+            <div className="flex items-start gap-2">
+              <div className="w-6 h-6 rounded-full bg-gray-400 text-white flex items-center justify-center text-xs font-bold flex-shrink-0 mt-0.5">
+                1
+              </div>
+              <div>
+                <div className="text-sm font-medium text-gray-900 dark:text-white">Unverified</div>
+                <div className="text-xs text-gray-600 dark:text-gray-400">Social media or single source</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-3 pt-3 border-t border-gray-200 dark:border-gray-700">
+            <a
+              href="/about"
+              className="text-xs text-blue-600 dark:text-blue-400 hover:underline"
+              target="_blank"
+            >
+              Learn more about evidence scoring →
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/components/FilterPanel.tsx
+++ b/frontend/components/FilterPanel.tsx
@@ -1,0 +1,270 @@
+'use client'
+
+import { useState } from 'react'
+import { FilterState } from '@/types'
+
+interface FilterPanelProps {
+  filters: FilterState
+  onChange: (filters: FilterState) => void
+  incidentCount: number
+  isOpen: boolean
+  onToggle: () => void
+}
+
+export function FilterPanel({ filters, onChange, incidentCount, isOpen, onToggle }: FilterPanelProps) {
+  const handleChange = (key: keyof FilterState, value: any) => {
+    onChange({ ...filters, [key]: value })
+  }
+
+  const activeFilterCount = [
+    filters.minEvidence > 1,
+    filters.country !== 'all',
+    filters.status !== 'all',
+    filters.assetType !== null,
+    filters.dateRange !== 'all'
+  ].filter(Boolean).length
+
+  const resetFilters = () => {
+    onChange({
+      minEvidence: 1,
+      country: 'all',
+      status: 'all',
+      assetType: null,
+      dateRange: 'all'
+    })
+  }
+
+  return (
+    <>
+      {/* Mobile: Floating Filter Button */}
+      <button
+        onClick={onToggle}
+        className="lg:hidden fixed bottom-6 right-6 z-[999] bg-blue-600 hover:bg-blue-700 text-white rounded-full shadow-2xl p-4 transition-all"
+      >
+        <div className="flex items-center gap-2">
+          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.293A1 1 0 013 6.586V4z" />
+          </svg>
+          {activeFilterCount > 0 && (
+            <span className="absolute -top-1 -right-1 bg-red-500 text-white text-xs font-bold rounded-full w-6 h-6 flex items-center justify-center">
+              {activeFilterCount}
+            </span>
+          )}
+        </div>
+      </button>
+
+      {/* Filter Panel Overlay (Mobile) */}
+      {isOpen && (
+        <div
+          className="lg:hidden fixed inset-0 bg-black/50 z-[998] backdrop-blur-sm"
+          onClick={onToggle}
+        />
+      )}
+
+      {/* Filter Panel */}
+      <div className={`
+        fixed lg:relative top-0 right-0 h-full
+        bg-white dark:bg-gray-900 border-l border-gray-200 dark:border-gray-800
+        shadow-2xl lg:shadow-none
+        transition-transform duration-300 ease-in-out
+        z-[999] lg:z-auto
+        w-80 lg:w-72
+        overflow-y-auto
+        ${isOpen ? 'translate-x-0' : 'translate-x-full lg:translate-x-0'}
+      `}>
+        <div className="p-4 space-y-4">
+          {/* Header */}
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-bold text-gray-900 dark:text-white">Filters</h2>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                {incidentCount} incident{incidentCount !== 1 ? 's' : ''}
+              </p>
+            </div>
+            <button
+              onClick={onToggle}
+              className="lg:hidden p-2 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-lg"
+            >
+              <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </button>
+          </div>
+
+          {/* Active Filters & Reset */}
+          {activeFilterCount > 0 && (
+            <div className="flex items-center justify-between p-2 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
+              <span className="text-sm text-blue-700 dark:text-blue-300">
+                {activeFilterCount} filter{activeFilterCount !== 1 ? 's' : ''} active
+              </span>
+              <button
+                onClick={resetFilters}
+                className="text-sm text-blue-600 dark:text-blue-400 hover:underline font-medium"
+              >
+                Clear all
+              </button>
+            </div>
+          )}
+
+          {/* Quick Filters */}
+          <div>
+            <label className="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider mb-2 block">
+              Quick Filters
+            </label>
+            <div className="flex flex-wrap gap-2">
+              <button
+                onClick={() => handleChange('assetType', 'airport')}
+                className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
+                  filters.assetType === 'airport'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                }`}
+              >
+                ✈️ Airports
+              </button>
+              <button
+                onClick={() => handleChange('assetType', 'military')}
+                className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
+                  filters.assetType === 'military'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                }`}
+              >
+                🛡️ Military
+              </button>
+              <button
+                onClick={() => handleChange('dateRange', 'day')}
+                className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
+                  filters.dateRange === 'day'
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                }`}
+              >
+                🕐 Today
+              </button>
+              <button
+                onClick={() => handleChange('minEvidence', 3)}
+                className={`px-3 py-1.5 text-sm rounded-full transition-colors ${
+                  filters.minEvidence >= 3
+                    ? 'bg-blue-600 text-white'
+                    : 'bg-gray-100 dark:bg-gray-800 text-gray-700 dark:text-gray-300 hover:bg-gray-200 dark:hover:bg-gray-700'
+                }`}
+              >
+                ✓ Verified Only
+              </button>
+            </div>
+          </div>
+
+          <hr className="border-gray-200 dark:border-gray-700" />
+
+          {/* Evidence Level */}
+          <div>
+            <label className="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider mb-2 block">
+              Evidence Level
+            </label>
+            <div className="space-y-2">
+              {[1, 2, 3, 4].map((level) => (
+                <button
+                  key={level}
+                  onClick={() => handleChange('minEvidence', level)}
+                  className={`w-full text-left px-3 py-2 rounded-lg transition-colors ${
+                    filters.minEvidence === level
+                      ? 'bg-blue-600 text-white'
+                      : 'bg-gray-50 dark:bg-gray-800 hover:bg-gray-100 dark:hover:bg-gray-700'
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium">
+                      {level === 1 && '1 - All Levels'}
+                      {level === 2 && '2+ OSINT'}
+                      {level === 3 && '3+ Verified'}
+                      {level === 4 && '4 Official Only'}
+                    </span>
+                    <div className={`w-3 h-3 rounded-full ${
+                      level === 1 && 'bg-gray-400'
+                    }${level === 2 && 'bg-yellow-400'}${
+                      level === 3 && 'bg-orange-500'
+                    }${level === 4 && 'bg-red-600'}`} />
+                  </div>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Country */}
+          <div>
+            <label className="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider mb-2 block">
+              Country
+            </label>
+            <select
+              value={filters.country}
+              onChange={(e) => handleChange('country', e.target.value)}
+              className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="all">All Countries</option>
+              <option value="DK">🇩🇰 Denmark</option>
+              <option value="NO">🇳🇴 Norway</option>
+              <option value="SE">🇸🇪 Sweden</option>
+              <option value="FI">🇫🇮 Finland</option>
+              <option value="PL">🇵🇱 Poland</option>
+              <option value="NL">🇳🇱 Netherlands</option>
+            </select>
+          </div>
+
+          {/* Status */}
+          <div>
+            <label className="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider mb-2 block">
+              Status
+            </label>
+            <select
+              value={filters.status}
+              onChange={(e) => handleChange('status', e.target.value)}
+              className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="all">All Status</option>
+              <option value="active">Active</option>
+              <option value="resolved">Resolved</option>
+              <option value="unconfirmed">Unconfirmed</option>
+            </select>
+          </div>
+
+          {/* Location Type */}
+          <div>
+            <label className="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider mb-2 block">
+              Location Type
+            </label>
+            <select
+              value={filters.assetType || ''}
+              onChange={(e) => handleChange('assetType', e.target.value || null)}
+              className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="">All Types</option>
+              <option value="airport">✈️ Airport</option>
+              <option value="harbor">⚓ Harbor</option>
+              <option value="military">🛡️ Military</option>
+              <option value="powerplant">⚡ Power Plant</option>
+              <option value="other">📍 Other</option>
+            </select>
+          </div>
+
+          {/* Time Range */}
+          <div>
+            <label className="text-xs font-semibold text-gray-700 dark:text-gray-300 uppercase tracking-wider mb-2 block">
+              Time Period
+            </label>
+            <select
+              value={filters.dateRange}
+              onChange={(e) => handleChange('dateRange', e.target.value)}
+              className="w-full px-3 py-2 bg-gray-50 dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-lg text-gray-900 dark:text-gray-100 focus:ring-2 focus:ring-blue-500"
+            >
+              <option value="day">Last 24 Hours</option>
+              <option value="week">Last 7 Days</option>
+              <option value="month">Last 30 Days</option>
+              <option value="all">All Time</option>
+            </select>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
## Summary
- Replaces old Filters component with a new FilterPanel supporting sidebar and mobile drawer modes
- Adds EvidenceLegend component to display evidence level explanations on the map view
- Introduces a view toggle bar for switching between Map, List, and Analytics views
- Moves Timeline component to only show on Map view
- Adds a new page_old.tsx preserving the previous page implementation for reference

## Changes

### UI Components
- **FilterPanel**: New comprehensive filter sidebar/drawer with quick filters, dropdowns, active filter count, and reset functionality
- **EvidenceLegend**: Collapsible legend explaining evidence levels with color-coded badges and descriptions
- **View Toggle Bar**: Buttons to switch between Map, List, and Analytics views with active state styling

### Page Updates
- Updated `frontend/app/page.tsx` to use FilterPanel and EvidenceLegend
- Timeline only visible on Map view
- Layout adjusted to accommodate new sidebar and toggle bar
- Added `frontend/app/page_old.tsx` as backup of previous page implementation

## Test plan
- [x] Verify filter panel opens/closes on desktop and mobile
- [x] Confirm filters update incident list correctly
- [x] Check evidence legend toggles open/closed and displays correct info
- [x] Test view toggle buttons switch views and highlight active
- [x] Ensure timeline only appears on Map view
- [x] Validate no regressions compared to old page implementation

🌿 Generated by [Terry](https://www.terragonlabs.com)

---

ℹ️ Tag @terragon-labs to ask questions and address PR feedback

📎 **Task**: https://www.terragonlabs.com/task/64b1aefb-4b1e-48ad-9695-e948737a2146